### PR TITLE
Fix typo in Docker hosting docs

### DIFF
--- a/docs/hosting/docker.md
+++ b/docs/hosting/docker.md
@@ -19,7 +19,7 @@ Complete the following steps:
 docker run hello-world
 ```
 
-### Step 2: Configure your Docker Compose file and environnment
+### Step 2: Configure your Docker Compose file and environment
 
 #### Create a directory for your app to run
 


### PR DESCRIPTION
## Summary
- fix heading typo in Docker hosting documentation

## Testing
- `bundle exec rake -T test` *(fails: lucide-rails.git not yet checked out)*